### PR TITLE
Add Edition management functionality

### DIFF
--- a/sls-api/Configuration/RepositoryConfig.cs
+++ b/sls-api/Configuration/RepositoryConfig.cs
@@ -12,6 +12,7 @@ namespace sls_api.Configuration
             services.AddScoped<ITeamRepo, TeamRepo>();
             services.AddScoped<ITournamentRepo, TournamentRepo>();
             services.AddScoped<IUserRepo, UserRepo>();
+            services.AddScoped<IEditionRepo, EditionRepo>();
 
             return services;
         }

--- a/sls-api/Controllers/EditionController.cs
+++ b/sls-api/Controllers/EditionController.cs
@@ -1,0 +1,61 @@
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using sls_borders.DTO.Admin;
+using sls_borders.DTO.EditionDto;
+using sls_borders.DTO.ErrorDto;
+using sls_borders.DTO.Game;
+using sls_borders.Models;
+using sls_borders.Repositories;
+using sls_repos.Repositories;
+
+namespace sls_api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class EditionController(IEditionRepo editionRepo, IMapper mapper) : ControllerBase
+    {
+        [Authorize(Roles = "Admin")]
+        [HttpGet("get-all")]
+        [ProducesResponseType<IEnumerable<GetEditionDto>>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<IEnumerable<GetEditionDto>>> GetAllEditions()
+        {
+            var editions = await editionRepo.GetAllAsync();
+            return Ok(mapper.Map<List<GetEditionDto>>(editions));
+        }
+
+        [HttpGet("{id}")]
+        [ProducesResponseType<GetEditionDto>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<GetEditionDto>> GetEditionById(Guid id)
+        {
+            var edition = await editionRepo.GetByIdAsync(id)!;
+            return Ok(mapper.Map<GetEditionDto>(edition));
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPost("create")]
+        [ProducesResponseType<GetEditionDto>(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<GetEditionDto>> CreateEdition([FromBody] CreateEditionDto createEditionDto)
+        {
+            if (!ModelState.IsValid)
+                return ValidationProblem(ModelState);
+
+            try
+            {
+                var createdEdition = await editionRepo.CreateAsync(createEditionDto);
+                return CreatedAtAction(nameof(GetEditionById), new { id = createdEdition.Id }, mapper.Map<GetEditionDto>(createdEdition));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Conflict(new ErrorResponse { Message = ex.Message });
+            }
+        }
+    }
+}

--- a/sls-api/Program.cs
+++ b/sls-api/Program.cs
@@ -17,7 +17,7 @@ builder.Services.AddOpenApi(options =>
 
 builder.Services.AddControllers();
 
-builder.Services.AddAutoMapper(typeof(AdminProfile), typeof(TeamProfile), typeof(TournamentProfile), typeof(GameProfile), typeof(UserProfile));
+builder.Services.AddAutoMapper(typeof(AdminProfile), typeof(TeamProfile), typeof(TournamentProfile), typeof(GameProfile), typeof(UserProfile), typeof(EditionProfile));
 
 // Configure CORS for development
 builder.Services.AddCors(options =>

--- a/sls-borders/DTO/EditionDto/CreateEditionDto.cs
+++ b/sls-borders/DTO/EditionDto/CreateEditionDto.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace sls_borders.DTO.EditionDto
+{
+    public class CreateEditionDto
+    {
+        public int Number { get; set; }
+        public DateOnly StartDate { get; set; }
+        public DateOnly EndDate { get; set; }
+        public string Organizer { get; set; } = null!;
+    }
+}

--- a/sls-borders/DTO/EditionDto/GetEditionDto.cs
+++ b/sls-borders/DTO/EditionDto/GetEditionDto.cs
@@ -1,0 +1,10 @@
+﻿namespace sls_borders.DTO.EditionDto
+{
+    public class GetEditionDto
+    {
+        public Guid Id { get; set; }
+        public int Number { get; set; }
+        public DateOnly StartDate { get; set; }
+        public DateOnly EndDate { get; set; }
+    }
+}

--- a/sls-borders/Mappings/EditionProfile.cs
+++ b/sls-borders/Mappings/EditionProfile.cs
@@ -1,0 +1,18 @@
+﻿using AutoMapper;
+using sls_borders.DTO.EditionDto;
+using sls_borders.Models;
+
+namespace sls_borders.Mappings
+{
+    public class EditionProfile : Profile
+    {
+        public EditionProfile()
+        {
+            CreateMap<Edition, GetEditionDto>();
+
+            CreateMap<CreateEditionDto, Edition>()
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => Guid.NewGuid()))
+                .ForMember(dest => dest.CreatedAt, opt => opt.MapFrom(src => DateTime.UtcNow));
+        }
+    }
+}

--- a/sls-borders/Models/Edition.cs
+++ b/sls-borders/Models/Edition.cs
@@ -1,0 +1,16 @@
+﻿
+namespace sls_borders.Models
+{
+    public class Edition
+    {
+        public Guid Id { get; set; }
+        public int Number { get; set; }
+        public DateOnly StartDate { get; set; }
+        public DateOnly EndDate { get; set; }
+        public string Organizer { get; set; } = null!;
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public ICollection<Team> Teams { get; set; } = new List<Team>();
+        public ICollection<Tournament> Tournaments { get; set; } = new List<Tournament>();
+    }
+}

--- a/sls-borders/Models/Team.cs
+++ b/sls-borders/Models/Team.cs
@@ -10,6 +10,9 @@ namespace sls_borders.Models
         public string Address { get; set; } = null!;
         public string Img { get; set; } = null!;
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public Guid EditionId { get; set; } = Guid.Empty;
+        public Edition Edition { get; set; } = null!;
+
 
         public ICollection<User> Users { get; set; } = new List<User>();
         public ICollection<Tournament> Tournaments { get; set; } = new List<Tournament>();

--- a/sls-borders/Models/Tournament.cs
+++ b/sls-borders/Models/Tournament.cs
@@ -10,6 +10,8 @@ namespace sls_borders.Models
         public TournamentStatus Status { get; set; } = TournamentStatus.Upcoming;
         public Guid OrganizingTeamId { get; set; } = Guid.Empty;
         public Team OrganizingTeam { get; set; } = null!;
+        public Guid EditionId { get; set; } = Guid.Empty;
+        public Edition Edition { get; set; } = null!;
 
         public ICollection<Team> Teams { get; set; } = new List<Team>();
         public ICollection<Game> Games { get; set; } = new List<Game>();

--- a/sls-borders/Repositories/IEditionRepo.cs
+++ b/sls-borders/Repositories/IEditionRepo.cs
@@ -1,0 +1,13 @@
+﻿using sls_borders.DTO.Admin;
+using sls_borders.DTO.EditionDto;
+using sls_borders.Models;
+
+namespace sls_borders.Repositories
+{
+    public interface IEditionRepo
+    {
+        Task<List<Edition>> GetAllAsync();
+        Task<Edition> CreateAsync(CreateEditionDto newEdition);
+        Task<Edition?> GetByIdAsync(Guid id);
+    }
+}

--- a/sls-repos/Data/ApplicationDbContext.cs
+++ b/sls-repos/Data/ApplicationDbContext.cs
@@ -12,6 +12,7 @@ namespace sls_borders.Data
         public DbSet<User> Users { get; set; } = null!;
         public DbSet<Tournament> Tournaments { get; set; } = null!;
         public DbSet<Game> Games { get; set; } = null!;
+        public DbSet<Edition> Editions { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -94,6 +95,32 @@ namespace sls_borders.Data
                 entity.HasOne<User>()
                     .WithMany(u => u.GamesAsBlack)
                     .HasForeignKey(g => g.BlackPlayerId)
+                    .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            modelBuilder.Entity<Edition>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Number).IsRequired();
+                entity.Property(e => e.StartDate)
+                    .HasColumnType("date");
+                entity.Property(e => e.EndDate)
+                    .HasColumnType("date");
+                entity.Property(e => e.Organizer).IsRequired().HasMaxLength(200);
+                entity.Property(e => e.CreatedAt).HasConversion(
+                    v => v,
+                    v => DateTime.SpecifyKind(v, DateTimeKind.Utc)
+                );
+
+                //One-to-many relationship with Teams
+                entity.HasMany(e => e.Teams)
+                    .WithOne(t => t.Edition)
+                    .HasForeignKey(t => t.EditionId)
+                    .OnDelete(DeleteBehavior.SetNull);
+                //One-to-many relationship with Tournaments
+                entity.HasMany(e => e.Tournaments)
+                    .WithOne(t => t.Edition)
+                    .HasForeignKey(t => t.EditionId)
                     .OnDelete(DeleteBehavior.SetNull);
             });
 

--- a/sls-repos/Migrations/20250805171650_AddTableEdition.Designer.cs
+++ b/sls-repos/Migrations/20250805171650_AddTableEdition.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using sls_borders.Data;
@@ -11,9 +12,11 @@ using sls_borders.Data;
 namespace sls_repos.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250805171650_AddTableEdition")]
+    partial class AddTableEdition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -73,23 +76,23 @@ namespace sls_repos.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<DateOnly>("EndDate")
-                        .HasColumnType("date");
+                    b.Property<DateTime>("EndDate")
+                        .HasColumnType("timestamp with time zone");
 
-                    b.Property<int>("Number")
+                    b.Property<int>("Nuber")
                         .HasColumnType("integer");
 
                     b.Property<string>("Organizer")
                         .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
 
-                    b.Property<DateOnly>("StartDate")
-                        .HasColumnType("date");
+                    b.Property<DateTime>("StartDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
-                    b.ToTable("Editions");
+                    b.ToTable("Edition");
                 });
 
             modelBuilder.Entity("sls_borders.Models.Game", b =>

--- a/sls-repos/Migrations/20250805171650_AddTableEdition.cs
+++ b/sls-repos/Migrations/20250805171650_AddTableEdition.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace sls_repos.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTableEdition : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "EditionId",
+                table: "Tournaments",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "EditionId",
+                table: "Teams",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateTable(
+                name: "Edition",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Nuber = table.Column<int>(type: "integer", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Organizer = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Edition", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tournaments_EditionId",
+                table: "Tournaments",
+                column: "EditionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Teams_EditionId",
+                table: "Teams",
+                column: "EditionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Teams_Edition_EditionId",
+                table: "Teams",
+                column: "EditionId",
+                principalTable: "Edition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tournaments_Edition_EditionId",
+                table: "Tournaments",
+                column: "EditionId",
+                principalTable: "Edition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Teams_Edition_EditionId",
+                table: "Teams");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tournaments_Edition_EditionId",
+                table: "Tournaments");
+
+            migrationBuilder.DropTable(
+                name: "Edition");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Tournaments_EditionId",
+                table: "Tournaments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Teams_EditionId",
+                table: "Teams");
+
+            migrationBuilder.DropColumn(
+                name: "EditionId",
+                table: "Tournaments");
+
+            migrationBuilder.DropColumn(
+                name: "EditionId",
+                table: "Teams");
+        }
+    }
+}

--- a/sls-repos/Migrations/20250805171836_AddTableEditionColNameChange.Designer.cs
+++ b/sls-repos/Migrations/20250805171836_AddTableEditionColNameChange.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using sls_borders.Data;
@@ -11,9 +12,11 @@ using sls_borders.Data;
 namespace sls_repos.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250805171836_AddTableEditionColNameChange")]
+    partial class AddTableEditionColNameChange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -73,23 +76,23 @@ namespace sls_repos.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<DateOnly>("EndDate")
-                        .HasColumnType("date");
+                    b.Property<DateTime>("EndDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Number")
                         .HasColumnType("integer");
 
                     b.Property<string>("Organizer")
                         .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
 
-                    b.Property<DateOnly>("StartDate")
-                        .HasColumnType("date");
+                    b.Property<DateTime>("StartDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
-                    b.ToTable("Editions");
+                    b.ToTable("Edition");
                 });
 
             modelBuilder.Entity("sls_borders.Models.Game", b =>

--- a/sls-repos/Migrations/20250805171836_AddTableEditionColNameChange.cs
+++ b/sls-repos/Migrations/20250805171836_AddTableEditionColNameChange.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace sls_repos.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTableEditionColNameChange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Nuber",
+                table: "Edition",
+                newName: "Number");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Number",
+                table: "Edition",
+                newName: "Nuber");
+        }
+    }
+}

--- a/sls-repos/Migrations/20250805174532_EditionTableOrgnizerMaxLengthChange.Designer.cs
+++ b/sls-repos/Migrations/20250805174532_EditionTableOrgnizerMaxLengthChange.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using sls_borders.Data;
@@ -11,9 +12,11 @@ using sls_borders.Data;
 namespace sls_repos.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250805174532_EditionTableOrgnizerMaxLengthChange")]
+    partial class EditionTableOrgnizerMaxLengthChange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -73,8 +76,8 @@ namespace sls_repos.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<DateOnly>("EndDate")
-                        .HasColumnType("date");
+                    b.Property<DateTime>("EndDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Number")
                         .HasColumnType("integer");
@@ -84,8 +87,8 @@ namespace sls_repos.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
-                    b.Property<DateOnly>("StartDate")
-                        .HasColumnType("date");
+                    b.Property<DateTime>("StartDate")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 

--- a/sls-repos/Migrations/20250805174532_EditionTableOrgnizerMaxLengthChange.cs
+++ b/sls-repos/Migrations/20250805174532_EditionTableOrgnizerMaxLengthChange.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace sls_repos.Migrations
+{
+    /// <inheritdoc />
+    public partial class EditionTableOrgnizerMaxLengthChange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Teams_Edition_EditionId",
+                table: "Teams");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tournaments_Edition_EditionId",
+                table: "Tournaments");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Edition",
+                table: "Edition");
+
+            migrationBuilder.RenameTable(
+                name: "Edition",
+                newName: "Editions");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Organizer",
+                table: "Editions",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Editions",
+                table: "Editions",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Teams_Editions_EditionId",
+                table: "Teams",
+                column: "EditionId",
+                principalTable: "Editions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tournaments_Editions_EditionId",
+                table: "Tournaments",
+                column: "EditionId",
+                principalTable: "Editions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Teams_Editions_EditionId",
+                table: "Teams");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tournaments_Editions_EditionId",
+                table: "Tournaments");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Editions",
+                table: "Editions");
+
+            migrationBuilder.RenameTable(
+                name: "Editions",
+                newName: "Edition");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Organizer",
+                table: "Edition",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Edition",
+                table: "Edition",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Teams_Edition_EditionId",
+                table: "Teams",
+                column: "EditionId",
+                principalTable: "Edition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tournaments_Edition_EditionId",
+                table: "Tournaments",
+                column: "EditionId",
+                principalTable: "Edition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/sls-repos/Migrations/20250805185143_EditionTableDateOnlyTypeChange.Designer.cs
+++ b/sls-repos/Migrations/20250805185143_EditionTableDateOnlyTypeChange.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using sls_borders.Data;
@@ -11,9 +12,11 @@ using sls_borders.Data;
 namespace sls_repos.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250805185143_EditionTableDateOnlyTypeChange")]
+    partial class EditionTableDateOnlyTypeChange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/sls-repos/Migrations/20250805185143_EditionTableDateOnlyTypeChange.cs
+++ b/sls-repos/Migrations/20250805185143_EditionTableDateOnlyTypeChange.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace sls_repos.Migrations
+{
+    /// <inheritdoc />
+    public partial class EditionTableDateOnlyTypeChange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "StartDate",
+                table: "Editions",
+                type: "date",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "EndDate",
+                table: "Editions",
+                type: "date",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "StartDate",
+                table: "Editions",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateOnly),
+                oldType: "date");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EndDate",
+                table: "Editions",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateOnly),
+                oldType: "date");
+        }
+    }
+}

--- a/sls-repos/Repositories/EditionRepo.cs
+++ b/sls-repos/Repositories/EditionRepo.cs
@@ -1,0 +1,30 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using sls_borders.Data;
+using sls_borders.DTO.Admin;
+using sls_borders.DTO.EditionDto;
+using sls_borders.Models;
+using sls_borders.Repositories;
+
+namespace sls_repos.Repositories;
+public class EditionRepo(ApplicationDbContext context, IMapper mapper) : IEditionRepo
+{
+    public async Task<List<Edition>> GetAllAsync()
+    {
+        return await context.Editions.ToListAsync();
+    }
+
+    public async Task<Edition> CreateAsync(CreateEditionDto newEdition)
+    {
+        var edition = mapper.Map<Edition>(newEdition);
+
+        context.Editions.Add(edition);
+        await context.SaveChangesAsync();
+        return edition;
+    }
+
+    public async Task<Edition?> GetByIdAsync(Guid id)
+    {
+        return await context.Editions.FindAsync(id);
+    }
+}


### PR DESCRIPTION
- Introduced `IEditionRepo` interface and its implementation in `EditionRepo` for managing editions.
- Created a new `Edition` class with properties like `Id`, `Number`, `StartDate`, `EndDate`, `Organizer`, and `CreatedAt`.
- Updated `ApplicationDbContext` to include `DbSet<Edition>` and configured relationships with `Team` and `Tournament`.
- Added database migrations to create the `Editions` table and added `EditionId` columns to `Teams` and `Tournaments`.
- Updated mapping profiles in `EditionProfile` for mapping between `Edition`, `GetEditionDto`, and `CreateEditionDto`.
- Implemented `EditionController` to handle CRUD operations for editions.
- Updated AutoMapper configuration in `Program.cs` to include the new `EditionProfile`.
- Modified migrations to adjust column data types in the `Editions` table, changing date types to `DateOnly` for `StartDate` and `EndDate`.
- Increased the maximum length of the `Organizer` column in the `Editions` table to 200 characters.
- Added new DTOs (`CreateEditionDto` and `GetEditionDto`) for handling input and output data for editions.