### PR TITLE
Add Color property to Edition model and DTOs

### DIFF
--- a/sls-borders/DTO/EditionDto/CreateEditionDto.cs
+++ b/sls-borders/DTO/EditionDto/CreateEditionDto.cs
@@ -9,6 +9,7 @@ namespace sls_borders.DTO.EditionDto
     public class CreateEditionDto
     {
         public int Number { get; set; }
+        public string Color { get; set; } = null!; // Hex color code
         public DateOnly StartDate { get; set; }
         public DateOnly EndDate { get; set; }
         public string Organizer { get; set; } = null!;

--- a/sls-borders/DTO/EditionDto/GetEditionDto.cs
+++ b/sls-borders/DTO/EditionDto/GetEditionDto.cs
@@ -4,6 +4,7 @@
     {
         public Guid Id { get; set; }
         public int Number { get; set; }
+        public string Color { get; set; } = null!; // Hex color code
         public DateOnly StartDate { get; set; }
         public DateOnly EndDate { get; set; }
     }

--- a/sls-borders/Models/Edition.cs
+++ b/sls-borders/Models/Edition.cs
@@ -5,6 +5,7 @@ namespace sls_borders.Models
     {
         public Guid Id { get; set; }
         public int Number { get; set; }
+        public string Color { get; set; } = null!; // Hex color code
         public DateOnly StartDate { get; set; }
         public DateOnly EndDate { get; set; }
         public string Organizer { get; set; } = null!;

--- a/sls-repos/Migrations/20250808093628_EditionColumnChange.Designer.cs
+++ b/sls-repos/Migrations/20250808093628_EditionColumnChange.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using sls_borders.Data;
@@ -11,9 +12,11 @@ using sls_borders.Data;
 namespace sls_repos.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250808093628_EditionColumnChange")]
+    partial class EditionColumnChange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/sls-repos/Migrations/20250808093628_EditionColumnChange.cs
+++ b/sls-repos/Migrations/20250808093628_EditionColumnChange.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace sls_repos.Migrations
+{
+    /// <inheritdoc />
+    public partial class EditionColumnChange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Color",
+                table: "Editions",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Color",
+                table: "Editions");
+        }
+    }
+}


### PR DESCRIPTION
Introduces a new 'Color' property (hex color code) to the Edition model, CreateEditionDto, and GetEditionDto. Updates the database schema via a migration to include the 'Color' column in the Editions table.